### PR TITLE
Fixed Linter Errors

### DIFF
--- a/internal/datasources/accounts.go
+++ b/internal/datasources/accounts.go
@@ -65,7 +65,7 @@ func accountsRead(
 		if managing != "" && acc.ManagingAccount != nil && *acc.ManagingAccount != managing {
 			continue
 		}
-		if name != "" && strings.ToLower(acc.Name) != strings.ToLower(name) {
+		if name != "" && !strings.EqualFold(acc.Name, name) {
 			continue
 		}
 		if ref != "" && acc.ExternalRef != nil && *acc.ExternalRef != ref {
@@ -83,7 +83,9 @@ func accountsRead(
 		state[i] = flat
 	}
 
-	res.Set("accounts", state)
+	if err := res.Set("accounts", state); err != nil {
+		return diag.FromErr(err)
+	}
 	res.SetId(schemas.Timestamp())
 
 	return nil
@@ -127,7 +129,7 @@ func accountRead(
 		if hasID && acc.ID != id.(string) {
 			continue
 		}
-		if hasName && strings.ToLower(acc.Name) != strings.ToLower(name.(string)) {
+		if hasName && !strings.EqualFold(acc.Name, name.(string)) {
 			continue
 		}
 		if hasRef && (acc.ExternalRef == nil || (acc.ExternalRef != nil && *acc.ExternalRef != ref.(string))) {

--- a/internal/datasources/facilities.go
+++ b/internal/datasources/facilities.go
@@ -102,7 +102,7 @@ func fetchFacilities(
 		if hasPdbFacilityID && *fac.PeeringdbFacilityID != pdbFacilityID.(int) {
 			continue
 		}
-		if hasName && strings.ToLower(fac.Name) != strings.ToLower(name.(string)) {
+		if hasName && !strings.EqualFold(fac.Name, name.(string)) {
 			continue
 		}
 		filtered = append(filtered, fac)
@@ -157,10 +157,10 @@ func facilityRead(
 		return err
 	}
 	if len(results) == 0 {
-		return fmt.Errorf("A facility could not be found")
+		return fmt.Errorf("a facility could not be found")
 	}
 	if len(results) > 1 {
-		return fmt.Errorf("Multiple facilities were returned")
+		return fmt.Errorf("multiple facilities were returned")
 	}
 
 	facility := results[0]

--- a/internal/datasources/metro_areas.go
+++ b/internal/datasources/metro_areas.go
@@ -43,7 +43,9 @@ func metroAreasRead(
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	res.Set("metro_areas", flatMetroAreas)
+	if err := res.Set("metro_areas", flatMetroAreas); err != nil {
+		return diag.FromErr(err)
+	}
 
 	// Assign pseudoID
 	res.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/internal/datasources/pops.go
+++ b/internal/datasources/pops.go
@@ -122,10 +122,10 @@ func popRead(
 			return err
 		}
 		if len(results) == 0 {
-			return fmt.Errorf("No point of presence did match the query")
+			return fmt.Errorf("no point of presence did match the query")
 		}
 		if len(results) > 1 {
-			return fmt.Errorf("The API returned more than one point of presence")
+			return fmt.Errorf("the API returned more than one point of presence")
 		}
 		pop = results[0]
 	}

--- a/internal/datasources/product_offerings_connection.go
+++ b/internal/datasources/product_offerings_connection.go
@@ -188,10 +188,10 @@ func productOfferingConnectionRead(
 			return err
 		}
 		if len(offerings) == 0 {
-			return fmt.Errorf("No connection product offering did match")
+			return fmt.Errorf("no connection product offering did match")
 		}
 		if len(offerings) > 1 {
-			return fmt.Errorf("The query did not return an unique connection product offering")
+			return fmt.Errorf("the query did not return a unique connection product offering")
 		}
 		offering = offerings[0]
 	}

--- a/internal/datasources/product_offerings_exchange_lan.go
+++ b/internal/datasources/product_offerings_exchange_lan.go
@@ -100,6 +100,9 @@ func exchangeLanProductOfferingsRead(
 ) diag.Diagnostics {
 	api := meta.(*ixapi.Client)
 	elpos, err := fetchExchangeLanProductOfferings(ctx, res, api)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	flat, err := schemas.FlattenModels(elpos)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/datasources/role_assignments.go
+++ b/internal/datasources/role_assignments.go
@@ -55,7 +55,7 @@ func fetchRoleByName(
 
 	for _, role := range roles {
 		// Match role by name (should be unique)
-		if strings.ToLower(role.Name) == strings.ToLower(name) {
+		if strings.EqualFold(role.Name, name) {
 			return role, nil
 		}
 	}
@@ -155,7 +155,7 @@ func roleAssignmentRead(
 		return diag.FromErr(err)
 	}
 
-	if schemas.SetResourceData(assignment, res); err != nil {
+	if err := schemas.SetResourceData(assignment, res); err != nil {
 		return diag.FromErr(err)
 	}
 	res.SetId(assignment.ID)

--- a/internal/ext/decix/datasources/cloud_router_arp_table_test.go
+++ b/internal/ext/decix/datasources/cloud_router_arp_table_test.go
@@ -52,7 +52,7 @@ func TestCloudRouterArpTableDataSourceRead(t *testing.T) {
 func TestCloudRouterArpTableDataSourceReadEmpty(t *testing.T) {
 	dataSource := NewDecixCloudRouterArpTableDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("vrf", "vrf-1")
+	_ = res.Set("vrf", "vrf-1")
 
 	api := ixapi.NewTestClient(map[string]any{
 		"/api/v3/decix-vrf-v1/arp-table": []*ixapi.CloudRouterArpEntry{},

--- a/internal/ext/decix/datasources/cloud_router_bfd_state.go
+++ b/internal/ext/decix/datasources/cloud_router_bfd_state.go
@@ -58,7 +58,9 @@ func cloudRouterBFDStateRead(
 	}
 
 	d.SetId(nscID)
-	d.Set("state", bfdState.State)
+	if err := d.Set("state", bfdState.State); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/internal/ext/decix/datasources/cloud_router_bfd_state_test.go
+++ b/internal/ext/decix/datasources/cloud_router_bfd_state_test.go
@@ -10,7 +10,7 @@ import (
 func TestCloudRouterBFDStateRead(t *testing.T) {
 	dataSource := NewDecixCloudRouterBFDStateDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("nsc_id", "123")
+	_ = res.Set("nsc_id", "123")
 
 	bfdState := &ixapi.CloudRouterBFDStateResponse{
 		State: "Up",
@@ -38,7 +38,7 @@ func TestCloudRouterBFDStateRead(t *testing.T) {
 func TestCloudRouterBFDStateRead_NotFound(t *testing.T) {
 	dataSource := NewDecixCloudRouterBFDStateDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("nsc_id", "456")
+	_ = res.Set("nsc_id", "456")
 
 	api := ixapi.NewTestClient(map[string]any{})
 	api.CloudRouterEnabled = true

--- a/internal/ext/decix/datasources/cloud_router_bgp_state.go
+++ b/internal/ext/decix/datasources/cloud_router_bgp_state.go
@@ -58,7 +58,9 @@ func cloudRouterBGPStateRead(
 	}
 
 	d.SetId(nscID)
-	d.Set("state", bgpState.State)
+	if err := d.Set("state", bgpState.State); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/internal/ext/decix/datasources/cloud_router_bgp_state_test.go
+++ b/internal/ext/decix/datasources/cloud_router_bgp_state_test.go
@@ -10,7 +10,7 @@ import (
 func TestCloudRouterBGPStateRead(t *testing.T) {
 	dataSource := NewDecixCloudRouterBGPStateDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("nsc_id", "123")
+	_ = res.Set("nsc_id", "123")
 
 	bgpState := &ixapi.CloudRouterBGPStateResponse{
 		State: "Established",
@@ -38,7 +38,7 @@ func TestCloudRouterBGPStateRead(t *testing.T) {
 func TestCloudRouterBGPStateRead_NotFound(t *testing.T) {
 	dataSource := NewDecixCloudRouterBGPStateDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("nsc_id", "456")
+	_ = res.Set("nsc_id", "456")
 
 	api := ixapi.NewTestClient(map[string]any{})
 	api.CloudRouterEnabled = true

--- a/internal/ext/decix/datasources/cloud_router_network_service_config_advertised_routes_test.go
+++ b/internal/ext/decix/datasources/cloud_router_network_service_config_advertised_routes_test.go
@@ -10,7 +10,7 @@ import (
 func TestCloudRouterNetworkServiceConfigAdvertisedRoutesDataSourceRead(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigAdvertisedRoutesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("network_service_config_id", "123")
+	_ = res.Set("network_service_config_id", "123")
 
 	routes := []*ixapi.CloudRouterBGPRoute{
 		{
@@ -47,7 +47,7 @@ func TestCloudRouterNetworkServiceConfigAdvertisedRoutesDataSourceRead(t *testin
 func TestCloudRouterNetworkServiceConfigAdvertisedRoutesDataSourceReadEmpty(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigAdvertisedRoutesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("network_service_config_id", "456")
+	_ = res.Set("network_service_config_id", "456")
 
 	routes := []*ixapi.CloudRouterBGPRoute{}
 

--- a/internal/ext/decix/datasources/cloud_router_network_service_config_received_routes_test.go
+++ b/internal/ext/decix/datasources/cloud_router_network_service_config_received_routes_test.go
@@ -10,7 +10,7 @@ import (
 func TestCloudRouterNetworkServiceConfigReceivedRoutesDataSourceRead(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigReceivedRoutesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("network_service_config_id", "123")
+	_ = res.Set("network_service_config_id", "123")
 
 	routes := []*ixapi.CloudRouterBGPRoute{
 		{
@@ -47,7 +47,7 @@ func TestCloudRouterNetworkServiceConfigReceivedRoutesDataSourceRead(t *testing.
 func TestCloudRouterNetworkServiceConfigReceivedRoutesDataSourceReadEmpty(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigReceivedRoutesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("network_service_config_id", "456")
+	_ = res.Set("network_service_config_id", "456")
 
 	routes := []*ixapi.CloudRouterBGPRoute{}
 

--- a/internal/ext/decix/datasources/cloud_router_network_service_configs_cloud_vc_test.go
+++ b/internal/ext/decix/datasources/cloud_router_network_service_configs_cloud_vc_test.go
@@ -48,7 +48,7 @@ func TestCloudRouterNetworkServiceConfigsCloudVCDataSourceRead(t *testing.T) {
 func TestCloudRouterNetworkServiceConfigsCloudVCDataSourceReadWithBFDFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigsCloudVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("bfd_enabled", true)
+	_ = res.Set("bfd_enabled", true)
 
 	configs := []*ixapi.CloudRouterNetworkServiceConfig{
 		{
@@ -92,7 +92,7 @@ func TestCloudRouterNetworkServiceConfigsCloudVCDataSourceReadWithBFDFilter(t *t
 func TestCloudRouterNetworkServiceConfigCloudVCDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigCloudVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "1")
+	_ = res.Set("id", "1")
 
 	config := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "1",
@@ -131,8 +131,8 @@ func TestCloudRouterNetworkServiceConfigCloudVCDataSourceReadByID(t *testing.T) 
 func TestCloudRouterNetworkServiceConfigsCloudVCDataSourceReadWithLimitOffset(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigsCloudVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("limit", 1)
-	res.Set("offset", 0)
+	_ = res.Set("limit", 1)
+	_ = res.Set("offset", 0)
 
 	configs := []*ixapi.CloudRouterNetworkServiceConfig{
 		{

--- a/internal/ext/decix/datasources/cloud_router_network_service_configs_p2p_vc_test.go
+++ b/internal/ext/decix/datasources/cloud_router_network_service_configs_p2p_vc_test.go
@@ -48,7 +48,7 @@ func TestCloudRouterNetworkServiceConfigsP2PVCDataSourceRead(t *testing.T) {
 func TestCloudRouterNetworkServiceConfigsP2PVCDataSourceReadWithBFDFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigsP2PVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("bfd_enabled", true)
+	_ = res.Set("bfd_enabled", true)
 
 	configs := []*ixapi.CloudRouterNetworkServiceConfig{
 		{
@@ -92,7 +92,7 @@ func TestCloudRouterNetworkServiceConfigsP2PVCDataSourceReadWithBFDFilter(t *tes
 func TestCloudRouterNetworkServiceConfigP2PVCDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigP2PVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "2")
+	_ = res.Set("id", "2")
 
 	config := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "2",
@@ -131,8 +131,8 @@ func TestCloudRouterNetworkServiceConfigP2PVCDataSourceReadByID(t *testing.T) {
 func TestCloudRouterNetworkServiceConfigsP2PVCDataSourceReadWithLimitOffset(t *testing.T) {
 	dataSource := NewDecixCloudRouterNetworkServiceConfigsP2PVCDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("limit", 1)
-	res.Set("offset", 1)
+	_ = res.Set("limit", 1)
+	_ = res.Set("offset", 1)
 
 	configs := []*ixapi.CloudRouterNetworkServiceConfig{
 		{

--- a/internal/ext/decix/datasources/cloud_router_policies_test.go
+++ b/internal/ext/decix/datasources/cloud_router_policies_test.go
@@ -74,7 +74,7 @@ func TestCloudRouterPoliciesDataSourceRead(t *testing.T) {
 func TestCloudRouterPoliciesDataSourceReadWithFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterPoliciesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("managing_account", "100")
+	_ = res.Set("managing_account", "100")
 
 	policies := []*ixapi.CloudRouterPolicy{
 		{
@@ -120,7 +120,7 @@ func TestCloudRouterPoliciesDataSourceReadWithFilter(t *testing.T) {
 func TestCloudRouterPolicyDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterPolicyDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "1")
+	_ = res.Set("id", "1")
 
 	policy := &ixapi.CloudRouterPolicy{
 		ID:               "1",
@@ -157,8 +157,8 @@ func TestCloudRouterPolicyDataSourceReadByID(t *testing.T) {
 func TestCloudRouterPolicyDataSourceReadByName(t *testing.T) {
 	dataSource := NewDecixCloudRouterPolicyDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("name", "accept-rfc1918")
-	res.Set("managing_account", "100")
+	_ = res.Set("name", "accept-rfc1918")
+	_ = res.Set("managing_account", "100")
 
 	policies := []*ixapi.CloudRouterPolicy{
 		{

--- a/internal/ext/decix/datasources/cloud_router_prefix_lists_test.go
+++ b/internal/ext/decix/datasources/cloud_router_prefix_lists_test.go
@@ -64,7 +64,7 @@ func TestCloudRouterPrefixListsDataSourceRead(t *testing.T) {
 func TestCloudRouterPrefixListsDataSourceReadWithFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterPrefixListsDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("managing_account", "100")
+	_ = res.Set("managing_account", "100")
 
 	prefixLists := []*ixapi.CloudRouterPrefixList{
 		{
@@ -106,7 +106,7 @@ func TestCloudRouterPrefixListsDataSourceReadWithFilter(t *testing.T) {
 func TestCloudRouterPrefixListDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterPrefixListDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "1")
+	_ = res.Set("id", "1")
 
 	prefixList := &ixapi.CloudRouterPrefixList{
 		ID:               "1",
@@ -140,8 +140,8 @@ func TestCloudRouterPrefixListDataSourceReadByID(t *testing.T) {
 func TestCloudRouterPrefixListDataSourceReadByName(t *testing.T) {
 	dataSource := NewDecixCloudRouterPrefixListDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("name", "rfc1918-private")
-	res.Set("managing_account", "100")
+	_ = res.Set("name", "rfc1918-private")
+	_ = res.Set("managing_account", "100")
 
 	prefixLists := []*ixapi.CloudRouterPrefixList{
 		{

--- a/internal/ext/decix/datasources/cloud_router_routes_test.go
+++ b/internal/ext/decix/datasources/cloud_router_routes_test.go
@@ -10,7 +10,7 @@ import (
 func TestCloudRouterRoutesDataSourceRead(t *testing.T) {
 	dataSource := NewDecixCloudRouterRoutesDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("vrf", "vrf-1")
+	_ = res.Set("vrf", "vrf-1")
 
 	routes := []*ixapi.CloudRouterVrfRoute{
 		{

--- a/internal/ext/decix/datasources/cloud_router_static_routes_test.go
+++ b/internal/ext/decix/datasources/cloud_router_static_routes_test.go
@@ -50,7 +50,7 @@ func TestCloudRouterStaticRoutesDataSourceRead(t *testing.T) {
 func TestCloudRouterStaticRouteDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterStaticRouteDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "route-1")
+	_ = res.Set("id", "route-1")
 
 	route := &ixapi.CloudRouterStaticRoute{
 		ID:                    "route-1",

--- a/internal/ext/decix/datasources/cloud_routers_test.go
+++ b/internal/ext/decix/datasources/cloud_routers_test.go
@@ -58,7 +58,7 @@ func TestCloudRoutersDataSourceRead(t *testing.T) {
 func TestCloudRoutersDataSourceReadWithFilter(t *testing.T) {
 	dataSource := NewDecixCloudRoutersDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("managing_account", "100")
+	_ = res.Set("managing_account", "100")
 
 	routers := []*ixapi.CloudRouter{
 		{
@@ -98,7 +98,7 @@ func TestCloudRoutersDataSourceReadWithFilter(t *testing.T) {
 func TestCloudRouterDataSourceReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "274")
+	_ = res.Set("id", "274")
 
 	router := &ixapi.CloudRouter{
 		ID:               "274",
@@ -137,7 +137,7 @@ func TestCloudRouterDataSourceReadByID(t *testing.T) {
 func TestCloudRouterDataSourceReadByExternalRef(t *testing.T) {
 	dataSource := NewDecixCloudRouterDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("external_ref", "my-router-ref")
+	_ = res.Set("external_ref", "my-router-ref")
 
 	externalRef := "my-router-ref"
 	routers := []*ixapi.CloudRouter{
@@ -173,7 +173,7 @@ func TestCloudRouterDataSourceReadByExternalRef(t *testing.T) {
 func TestCloudRouterDataSourceRead_MultipleResultsError(t *testing.T) {
 	dataSource := NewDecixCloudRouterDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("external_ref", "shared-ref")
+	_ = res.Set("external_ref", "shared-ref")
 
 	externalRef := "shared-ref"
 	routers := []*ixapi.CloudRouter{

--- a/internal/ext/decix/datasources/product_offerings_cloud_vrf_test.go
+++ b/internal/ext/decix/datasources/product_offerings_cloud_vrf_test.go
@@ -58,7 +58,7 @@ func TestProductOfferingsCloudVRFRead(t *testing.T) {
 func TestProductOfferingsCloudVRFReadWithFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterProductOfferingsCloudVRFDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("contract_period", "P1Y")
+	_ = res.Set("contract_period", "P1Y")
 
 	offerings := []*ixapi.CloudRouterProductOffering{
 		{
@@ -94,7 +94,7 @@ func TestProductOfferingsCloudVRFReadWithFilter(t *testing.T) {
 func TestProductOfferingCloudVRFReadByID(t *testing.T) {
 	dataSource := NewDecixCloudRouterProductOfferingCloudVRFDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("id", "po-1")
+	_ = res.Set("id", "po-1")
 
 	offering := &ixapi.CloudRouterProductOffering{
 		ID:             "po-1",
@@ -128,7 +128,7 @@ func TestProductOfferingCloudVRFReadByID(t *testing.T) {
 func TestProductOfferingCloudVRFRead_UniqueFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterProductOfferingCloudVRFDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("name", "cloud-router-1g")
+	_ = res.Set("name", "cloud-router-1g")
 
 	offerings := []*ixapi.CloudRouterProductOffering{
 		{
@@ -158,7 +158,7 @@ func TestProductOfferingCloudVRFRead_UniqueFilter(t *testing.T) {
 func TestProductOfferingCloudVRFRead_AmbiguousFilter(t *testing.T) {
 	dataSource := NewDecixCloudRouterProductOfferingCloudVRFDataSource()
 	res := dataSource.TestResourceData()
-	res.Set("service_metro_area", "de-fra")
+	_ = res.Set("service_metro_area", "de-fra")
 
 	offerings := []*ixapi.CloudRouterProductOffering{
 		{

--- a/internal/ext/decix/resources/cloud_router_network_service_config_cloud_vc_test.go
+++ b/internal/ext/decix/resources/cloud_router_network_service_config_cloud_vc_test.go
@@ -10,17 +10,17 @@ import (
 func TestCloudRouterConfigCloudVCRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigCloudVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "enabled")
-	res.Set("bfd_enabled", true)
-	res.Set("cloud_vlan", 100)
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "enabled")
+	_ = res.Set("bfd_enabled", true)
+	_ = res.Set("cloud_vlan", 100)
 
 	req, err := cloudRouterConfigCloudVCRequestFromResourceData(res)
 	if err != nil {
@@ -106,15 +106,15 @@ func TestCloudRouterConfigCloudVCRead(t *testing.T) {
 func TestCloudRouterConfigCloudVCCreate(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigCloudVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "enabled")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "enabled")
 
 	created := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "10",
@@ -157,8 +157,8 @@ func TestCloudRouterConfigCloudVCPatchFromResourceData(t *testing.T) {
 
 	t.Run("set fields are included", func(t *testing.T) {
 		res := resource.Data(nil)
-		res.Set("admin_status", "enabled")
-		res.Set("policy_egress", "my-egress")
+		_ = res.Set("admin_status", "enabled")
+		_ = res.Set("policy_egress", "my-egress")
 
 		patch := cloudRouterConfigCloudVCPatchFromResourceData(res)
 
@@ -194,15 +194,15 @@ func TestCloudRouterConfigCloudVCUpdate(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigCloudVCResource()
 	res := resource.Data(nil)
 	res.SetId("10")
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "disabled")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "disabled")
 
 	updated := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "10",

--- a/internal/ext/decix/resources/cloud_router_network_service_config_p2p_vc_test.go
+++ b/internal/ext/decix/resources/cloud_router_network_service_config_p2p_vc_test.go
@@ -10,17 +10,17 @@ import (
 func TestCloudRouterConfigP2PVCRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigP2PVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "enabled")
-	res.Set("bfd_enabled", false)
-	res.Set("network_connection", "conn-abc123")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "enabled")
+	_ = res.Set("bfd_enabled", false)
+	_ = res.Set("network_connection", "conn-abc123")
 
 	req, err := cloudRouterConfigP2PVCRequestFromResourceData(res)
 	if err != nil {
@@ -92,16 +92,16 @@ func TestCloudRouterConfigP2PVCRead(t *testing.T) {
 func TestCloudRouterConfigP2PVCCreate(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigP2PVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "enabled")
-	res.Set("network_connection", "conn-abc123")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "enabled")
+	_ = res.Set("network_connection", "conn-abc123")
 
 	created := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "20",
@@ -145,8 +145,8 @@ func TestCloudRouterConfigP2PVCPatchFromResourceData(t *testing.T) {
 
 	t.Run("set fields are included", func(t *testing.T) {
 		res := resource.Data(nil)
-		res.Set("admin_status", "enabled")
-		res.Set("policy_ingress", "my-ingress")
+		_ = res.Set("admin_status", "enabled")
+		_ = res.Set("policy_ingress", "my-ingress")
 
 		patch := cloudRouterConfigP2PVCPatchFromResourceData(res)
 
@@ -182,15 +182,15 @@ func TestCloudRouterConfigP2PVCUpdate(t *testing.T) {
 	resource := NewDecixCloudRouterNetworkServiceConfigP2PVCResource()
 	res := resource.Data(nil)
 	res.SetId("20")
-	res.Set("managing_account", "100")
-	res.Set("billing_account", "200")
-	res.Set("consuming_account", "300")
-	res.Set("cloud_router", "274")
-	res.Set("network_service", "500")
-	res.Set("address", "192.0.2.1/30")
-	res.Set("bgp_neighbor", "192.0.2.2")
-	res.Set("bgp_neighbor_asn", 64512)
-	res.Set("admin_status", "disabled")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("billing_account", "200")
+	_ = res.Set("consuming_account", "300")
+	_ = res.Set("cloud_router", "274")
+	_ = res.Set("network_service", "500")
+	_ = res.Set("address", "192.0.2.1/30")
+	_ = res.Set("bgp_neighbor", "192.0.2.2")
+	_ = res.Set("bgp_neighbor_asn", 64512)
+	_ = res.Set("admin_status", "disabled")
 
 	updated := &ixapi.CloudRouterNetworkServiceConfig{
 		ID:               "20",

--- a/internal/ext/decix/resources/cloud_router_policy_test.go
+++ b/internal/ext/decix/resources/cloud_router_policy_test.go
@@ -10,10 +10,10 @@ import (
 func TestPolicyRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterPolicyResource()
 	res := resource.Data(nil)
-	res.Set("name", "accept-rfc1918")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("entries", []interface{}{
+	_ = res.Set("name", "accept-rfc1918")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("entries", []interface{}{
 		map[string]interface{}{
 			"sequence_number":   10,
 			"match_prefix_list": "rfc1918-private",
@@ -72,10 +72,10 @@ func TestPolicyRequestFromResourceData(t *testing.T) {
 func TestPolicyRequestFromResourceData_WithASPathPrepend(t *testing.T) {
 	resource := NewDecixCloudRouterPolicyResource()
 	res := resource.Data(nil)
-	res.Set("name", "prepend-policy")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("entries", []interface{}{
+	_ = res.Set("name", "prepend-policy")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("entries", []interface{}{
 		map[string]interface{}{
 			"sequence_number":   10,
 			"match_prefix_list": "",
@@ -159,10 +159,10 @@ func TestPolicyRead(t *testing.T) {
 func TestPolicyCreate(t *testing.T) {
 	resource := NewDecixCloudRouterPolicyResource()
 	res := resource.Data(nil)
-	res.Set("name", "accept-rfc1918")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("entries", []interface{}{
+	_ = res.Set("name", "accept-rfc1918")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("entries", []interface{}{
 		map[string]interface{}{
 			"sequence_number":   10,
 			"match_prefix_list": "",
@@ -216,10 +216,10 @@ func TestPolicyUpdate(t *testing.T) {
 	resource := NewDecixCloudRouterPolicyResource()
 	res := resource.Data(nil)
 	res.SetId("55")
-	res.Set("name", "updated-policy")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("entries", []interface{}{
+	_ = res.Set("name", "updated-policy")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("entries", []interface{}{
 		map[string]interface{}{
 			"sequence_number":   10,
 			"match_prefix_list": "",

--- a/internal/ext/decix/resources/cloud_router_prefix_list_test.go
+++ b/internal/ext/decix/resources/cloud_router_prefix_list_test.go
@@ -10,10 +10,10 @@ import (
 func TestPrefixListRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterPrefixListResource()
 	res := resource.Data(nil)
-	res.Set("name", "test-list")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("match_list", []interface{}{
+	_ = res.Set("name", "test-list")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("match_list", []interface{}{
 		map[string]interface{}{
 			"prefix":     "192.168.0.0/16",
 			"min_length": 0,
@@ -101,10 +101,10 @@ func TestPrefixListRead(t *testing.T) {
 func TestPrefixListCreate(t *testing.T) {
 	resource := NewDecixCloudRouterPrefixListResource()
 	res := resource.Data(nil)
-	res.Set("name", "rfc1918-private")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("match_list", []interface{}{
+	_ = res.Set("name", "rfc1918-private")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("match_list", []interface{}{
 		map[string]interface{}{
 			"prefix":     "192.168.0.0/16",
 			"min_length": 0,
@@ -148,10 +148,10 @@ func TestPrefixListUpdate(t *testing.T) {
 	resource := NewDecixCloudRouterPrefixListResource()
 	res := resource.Data(nil)
 	res.SetId("42")
-	res.Set("name", "updated-list")
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("match_list", []interface{}{
+	_ = res.Set("name", "updated-list")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("match_list", []interface{}{
 		map[string]interface{}{
 			"prefix":     "10.0.0.0/8",
 			"min_length": 0,

--- a/internal/ext/decix/resources/cloud_router_static_route_test.go
+++ b/internal/ext/decix/resources/cloud_router_static_route_test.go
@@ -10,10 +10,10 @@ import (
 func TestStaticRouteRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterStaticRouteResource()
 	res := resource.Data(nil)
-	res.Set("name", "test-route")
-	res.Set("prefix", "10.0.0.0/24")
-	res.Set("next_hop", "192.168.1.1")
-	res.Set("network_service_configs", []interface{}{"nsc-1", "nsc-2"})
+	_ = res.Set("name", "test-route")
+	_ = res.Set("prefix", "10.0.0.0/24")
+	_ = res.Set("next_hop", "192.168.1.1")
+	_ = res.Set("network_service_configs", []interface{}{"nsc-1", "nsc-2"})
 
 	req, err := staticRouteRequestFromResourceData(res)
 	if err != nil {
@@ -83,10 +83,10 @@ func TestStaticRouteRead(t *testing.T) {
 func TestStaticRouteCreate(t *testing.T) {
 	resource := NewDecixCloudRouterStaticRouteResource()
 	res := resource.Data(nil)
-	res.Set("name", "my-route")
-	res.Set("prefix", "10.0.0.0/24")
-	res.Set("next_hop", "aggregate")
-	res.Set("network_service_configs", []interface{}{"nsc-abc"})
+	_ = res.Set("name", "my-route")
+	_ = res.Set("prefix", "10.0.0.0/24")
+	_ = res.Set("next_hop", "aggregate")
+	_ = res.Set("network_service_configs", []interface{}{"nsc-abc"})
 
 	created := &ixapi.CloudRouterStaticRoute{
 		ID:                    "route-42",
@@ -123,10 +123,10 @@ func TestStaticRouteUpdate(t *testing.T) {
 	resource := NewDecixCloudRouterStaticRouteResource()
 	res := resource.Data(nil)
 	res.SetId("route-42")
-	res.Set("name", "updated-route")
-	res.Set("prefix", "172.16.0.0/16")
-	res.Set("next_hop", "10.0.0.1")
-	res.Set("network_service_configs", []interface{}{"nsc-abc"})
+	_ = res.Set("name", "updated-route")
+	_ = res.Set("prefix", "172.16.0.0/16")
+	_ = res.Set("next_hop", "10.0.0.1")
+	_ = res.Set("network_service_configs", []interface{}{"nsc-abc"})
 
 	updated := &ixapi.CloudRouterStaticRoute{
 		ID:                    "route-42",

--- a/internal/ext/decix/resources/cloud_router_test.go
+++ b/internal/ext/decix/resources/cloud_router_test.go
@@ -10,13 +10,13 @@ import (
 func TestCloudRouterRequestFromResourceData(t *testing.T) {
 	resource := NewDecixCloudRouterResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("billing_account", "300")
-	res.Set("product_offering", "1")
-	res.Set("asn", 65001)
-	res.Set("capacity", 1000)
-	res.Set("external_ref", "test-ref")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("billing_account", "300")
+	_ = res.Set("product_offering", "1")
+	_ = res.Set("asn", 65001)
+	_ = res.Set("capacity", 1000)
+	_ = res.Set("external_ref", "test-ref")
 
 	req, err := cloudRouterRequestFromResourceData(res)
 	if err != nil {
@@ -140,12 +140,12 @@ func TestCloudRouterDelete_OtherErrorFails(t *testing.T) {
 func TestCloudRouterCreate(t *testing.T) {
 	resource := NewDecixCloudRouterResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("billing_account", "300")
-	res.Set("product_offering", "1")
-	res.Set("asn", 65001)
-	res.Set("capacity", 1000)
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("billing_account", "300")
+	_ = res.Set("product_offering", "1")
+	_ = res.Set("asn", 65001)
+	_ = res.Set("capacity", 1000)
 
 	createdRouter := &ixapi.CloudRouter{
 		ID:               "274",
@@ -189,13 +189,13 @@ func TestCloudRouterCreate(t *testing.T) {
 func TestCloudRouterCreate_WithExternalRef(t *testing.T) {
 	resource := NewDecixCloudRouterResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("billing_account", "300")
-	res.Set("product_offering", "1")
-	res.Set("asn", 65001)
-	res.Set("capacity", 1000)
-	res.Set("external_ref", "my-router-ref")
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("billing_account", "300")
+	_ = res.Set("product_offering", "1")
+	_ = res.Set("asn", 65001)
+	_ = res.Set("capacity", 1000)
+	_ = res.Set("external_ref", "my-router-ref")
 
 	externalRef := "my-router-ref"
 	createdRouter := &ixapi.CloudRouter{
@@ -236,12 +236,12 @@ func TestCloudRouterCreate_WithExternalRef(t *testing.T) {
 func TestCloudRouterCreate_APIError(t *testing.T) {
 	resource := NewDecixCloudRouterResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "100")
-	res.Set("consuming_account", "200")
-	res.Set("billing_account", "300")
-	res.Set("product_offering", "1")
-	res.Set("asn", 65001)
-	res.Set("capacity", 1000)
+	_ = res.Set("managing_account", "100")
+	_ = res.Set("consuming_account", "200")
+	_ = res.Set("billing_account", "300")
+	_ = res.Set("product_offering", "1")
+	_ = res.Set("asn", 65001)
+	_ = res.Set("capacity", 1000)
 
 	api := ixapi.NewTestClient(map[string]any{
 		"/api/v3/decix-vrf-v1/vrfs": (ixapi.TestResponseFunc)(func(body []byte) (any, error) {

--- a/internal/filter/string.go
+++ b/internal/filter/string.go
@@ -29,5 +29,5 @@ func Missing(a any, b any, apply bool) bool {
 		}
 		v2 = *v
 	}
-	return strings.ToLower(v1) != strings.ToLower(v2)
+	return !strings.EqualFold(v1, v2)
 }

--- a/internal/filter/string_test.go
+++ b/internal/filter/string_test.go
@@ -16,7 +16,7 @@ func TestMissingFilter(t *testing.T) {
 	}
 
 	// Optional strings
-	var opt *string = &a
+	opt := &a
 	if Missing(opt, "foo", true) {
 		t.Error("should return true, because opt is foo")
 	}

--- a/internal/ixapi/extension_types.go
+++ b/internal/ixapi/extension_types.go
@@ -103,10 +103,10 @@ func (ft *APITimestamp) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements json.Marshaler, serializing to RFC3339 or null if zero.
 func (ft APITimestamp) MarshalJSON() ([]byte, error) {
-	if ft.Time.IsZero() {
+	if ft.IsZero() {
 		return []byte("null"), nil
 	}
-	return []byte(`"` + ft.Time.Format(time.RFC3339) + `"`), nil
+	return []byte(`"` + ft.Format(time.RFC3339) + `"`), nil
 }
 
 // NewAPITimestamp wraps a *time.Time in a APITimestamp, returning nil if the input is nil.
@@ -124,7 +124,7 @@ func APITimestampNowUTC() APITimestamp {
 
 // ToTime returns the underlying *time.Time, or nil if the receiver is nil or zero.
 func (ft *APITimestamp) ToTime() *time.Time {
-	if ft == nil || ft.Time.IsZero() {
+	if ft == nil || ft.IsZero() {
 		return nil
 	}
 	t := ft.Time

--- a/internal/ixapi/extension_types_test.go
+++ b/internal/ixapi/extension_types_test.go
@@ -60,7 +60,7 @@ func TestAPITimestamp_UnmarshalJSON_RFC3339(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	expected := time.Date(2024, 8, 1, 14, 30, 0, 0, time.UTC)
-	if !ft.Time.Equal(expected) {
+	if !ft.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, ft.Time)
 	}
 }
@@ -74,7 +74,7 @@ func TestAPITimestamp_UnmarshalJSON_DateOnly(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	expected := time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)
-	if !ft.Time.Equal(expected) {
+	if !ft.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, ft.Time)
 	}
 }
@@ -85,7 +85,7 @@ func TestAPITimestamp_UnmarshalJSON_Null(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !ft.Time.IsZero() {
+	if !ft.IsZero() {
 		t.Errorf("expected zero time, got %v", ft.Time)
 	}
 }
@@ -96,7 +96,7 @@ func TestAPITimestamp_UnmarshalJSON_EmptyString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !ft.Time.IsZero() {
+	if !ft.IsZero() {
 		t.Errorf("expected zero time, got %v", ft.Time)
 	}
 }
@@ -134,7 +134,7 @@ func TestAPITimestamp_UnmarshalJSON_SpaceSeparated(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	expected := time.Date(2024, 8, 1, 14, 30, 0, 0, time.UTC)
-	if !ft.Time.Equal(expected) {
+	if !ft.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, ft.Time)
 	}
 }

--- a/internal/ixapi/resources.go
+++ b/internal/ixapi/resources.go
@@ -56,7 +56,7 @@ func (c *Client) AuthTokenCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (c *Client) AuthTokenRefresh(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -352,7 +352,7 @@ func (c *Client) FacilitiesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -444,7 +444,7 @@ func (c *Client) FacilitiesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -627,7 +627,7 @@ func (c *Client) DevicesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -719,7 +719,7 @@ func (c *Client) DevicesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -888,7 +888,7 @@ func (c *Client) PopsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -980,7 +980,7 @@ func (c *Client) PopsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1114,7 +1114,7 @@ func (c *Client) MetroAreaNetworksList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1206,7 +1206,7 @@ func (c *Client) MetroAreaNetworksRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1319,7 +1319,7 @@ func (c *Client) MetroAreasList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1411,7 +1411,7 @@ func (c *Client) MetroAreasRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1650,7 +1650,7 @@ func (c *Client) ProductOfferingsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1803,7 +1803,7 @@ func (c *Client) ProductOfferingsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2032,7 +2032,7 @@ func (c *Client) PortsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2124,7 +2124,7 @@ func (c *Client) PortsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2272,7 +2272,7 @@ func (c *Client) PortReservationsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2380,7 +2380,7 @@ func (c *Client) PortReservationsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2472,7 +2472,7 @@ func (c *Client) PortReservationsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2569,7 +2569,7 @@ func (c *Client) PortReservationsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2666,7 +2666,7 @@ func (c *Client) PortReservationsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2765,7 +2765,7 @@ func (c *Client) PortReservationsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2891,7 +2891,7 @@ func (c *Client) PortReservationCancellationPolicy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2987,7 +2987,7 @@ func (c *Client) PortReservationsLoaDownload(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3074,7 +3074,7 @@ func (c *Client) PortReservationsLoaUpload(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3258,7 +3258,7 @@ func (c *Client) ConnectionsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3373,7 +3373,7 @@ func (c *Client) ConnectionsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3465,7 +3465,7 @@ func (c *Client) ConnectionsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3562,7 +3562,7 @@ func (c *Client) ConnectionsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3659,7 +3659,7 @@ func (c *Client) ConnectionsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3771,7 +3771,7 @@ func (c *Client) ConnectionsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3865,7 +3865,7 @@ func (c *Client) ConnectionsLoaDownload(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -3955,7 +3955,7 @@ func (c *Client) ConnectionsLoaUpload(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4075,7 +4075,7 @@ func (c *Client) ConnectionsCancellationPolicy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4286,7 +4286,7 @@ func (c *Client) NetworkServiceConfigsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4466,7 +4466,7 @@ func (c *Client) NetworkServiceConfigsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4633,7 +4633,7 @@ func (c *Client) NetworkServiceConfigsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4805,7 +4805,7 @@ func (c *Client) NetworkServiceConfigsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -4977,7 +4977,7 @@ func (c *Client) NetworkServiceConfigsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5154,7 +5154,7 @@ func (c *Client) NetworkServiceConfigsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5355,7 +5355,7 @@ func (c *Client) NetworkServiceConfigCancellationPolicyRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5538,7 +5538,7 @@ func (c *Client) NetworkFeatureConfigsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5657,7 +5657,7 @@ func (c *Client) NetworkFeatureConfigsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5762,7 +5762,7 @@ func (c *Client) NetworkFeatureConfigsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5872,7 +5872,7 @@ func (c *Client) NetworkFeatureConfigsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -5982,7 +5982,7 @@ func (c *Client) NetworkFeatureConfigsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6092,7 +6092,7 @@ func (c *Client) NetworkFeatureConfigsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6267,7 +6267,7 @@ func (c *Client) AccountsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6364,7 +6364,7 @@ func (c *Client) AccountsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6456,7 +6456,7 @@ func (c *Client) AccountsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6553,7 +6553,7 @@ func (c *Client) AccountsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6650,7 +6650,7 @@ func (c *Client) AccountsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6750,7 +6750,7 @@ func (c *Client) AccountsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6877,7 +6877,7 @@ func (c *Client) RolesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -6969,7 +6969,7 @@ func (c *Client) RolesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7103,7 +7103,7 @@ func (c *Client) ContactsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7200,7 +7200,7 @@ func (c *Client) ContactsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7292,7 +7292,7 @@ func (c *Client) ContactsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7389,7 +7389,7 @@ func (c *Client) ContactsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7486,7 +7486,7 @@ func (c *Client) ContactsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7582,7 +7582,7 @@ func (c *Client) ContactsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7709,7 +7709,7 @@ func (c *Client) RoleAssignmentsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7810,7 +7810,7 @@ func (c *Client) RoleAssignmentsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7902,7 +7902,7 @@ func (c *Client) RoleAssignmentsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -7997,7 +7997,7 @@ func (c *Client) RoleAssignmentsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8088,7 +8088,7 @@ func (c *Client) APIHealthRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8179,7 +8179,7 @@ func (c *Client) APIImplementationRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8270,7 +8270,7 @@ func (c *Client) APIExtensionsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8467,7 +8467,7 @@ func (c *Client) IPsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8564,7 +8564,7 @@ func (c *Client) IPsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8656,7 +8656,7 @@ func (c *Client) IPsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8760,7 +8760,7 @@ func (c *Client) IPsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -8865,7 +8865,7 @@ func (c *Client) IPsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9027,7 +9027,7 @@ func (c *Client) MacsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9124,7 +9124,7 @@ func (c *Client) MacsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9216,7 +9216,7 @@ func (c *Client) MacsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9308,7 +9308,7 @@ func (c *Client) MacsDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9477,7 +9477,7 @@ func (c *Client) NetworkServicesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9627,7 +9627,7 @@ func (c *Client) NetworkServicesCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9764,7 +9764,7 @@ func (c *Client) NetworkServicesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -9906,7 +9906,7 @@ func (c *Client) NetworkServicesUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10048,7 +10048,7 @@ func (c *Client) NetworkServicesPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10208,7 +10208,7 @@ func (c *Client) NetworkServicesDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10345,7 +10345,7 @@ func (c *Client) NetworkServiceChangeRequestRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10470,7 +10470,7 @@ func (c *Client) NetworkServiceChangeRequestCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10562,7 +10562,7 @@ func (c *Client) NetworkServiceChangeRequestDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10688,7 +10688,7 @@ func (c *Client) NetworkServiceCancellationPolicyRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10829,7 +10829,7 @@ func (c *Client) NetworkFeaturesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -10942,7 +10942,7 @@ func (c *Client) NetworkFeaturesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11075,7 +11075,7 @@ func (c *Client) MemberJoiningRulesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11201,7 +11201,7 @@ func (c *Client) MemberJoiningRulesCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11314,7 +11314,7 @@ func (c *Client) MemberJoiningRulesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11432,7 +11432,7 @@ func (c *Client) MemberJoiningRulesUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11550,7 +11550,7 @@ func (c *Client) MemberJoiningRulesPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -11663,7 +11663,7 @@ func (c *Client) MemberJoiningRulesDestroy(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err

--- a/internal/ixapi/resources_cloud_router.go
+++ b/internal/ixapi/resources_cloud_router.go
@@ -71,7 +71,7 @@ func (c *Client) DecixCloudRoutersList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (c *Client) DecixCloudRoutersCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (c *Client) DecixCloudRoutersRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -297,7 +297,7 @@ func (c *Client) DecixCloudRoutersDestroy(
 	if err != nil {
 		return err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return err
@@ -405,7 +405,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -492,7 +492,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -570,7 +570,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -656,7 +656,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsPatch(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -734,7 +734,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsDestroy(
 	if err != nil {
 		return err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return err
@@ -787,14 +787,14 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigsDestroy(
 
 // CloudRouterProductOfferingsListQuery holds query parameters for listing Cloud Router product offerings.
 type CloudRouterProductOfferingsListQuery struct {
-	Limit                    int    `json:"limit,omitempty"`
-	Offset                   int    `json:"offset,omitempty"`
-	ID                       string `json:"id,omitempty"`
-	Bandwidth                int    `json:"bandwidth,omitempty"`
-	Name                     string `json:"name,omitempty"`
-	ServiceMetroArea         string `json:"service_metro_area,omitempty"`
-	ServiceMetroAreaNetwork  string `json:"service_metro_area_network,omitempty"`
-	ContractPeriod           string `json:"contract_period,omitempty"`
+	Limit                   int    `json:"limit,omitempty"`
+	Offset                  int    `json:"offset,omitempty"`
+	ID                      string `json:"id,omitempty"`
+	Bandwidth               int    `json:"bandwidth,omitempty"`
+	Name                    string `json:"name,omitempty"`
+	ServiceMetroArea        string `json:"service_metro_area,omitempty"`
+	ServiceMetroAreaNetwork string `json:"service_metro_area_network,omitempty"`
+	ContractPeriod          string `json:"contract_period,omitempty"`
 }
 
 // RawQuery encodes the query parameters as a URL query string.
@@ -850,7 +850,7 @@ func (c *Client) DecixCloudRouterProductOfferingsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -923,7 +923,7 @@ func (c *Client) DecixCloudRouterProductOfferingsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -996,7 +996,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigGetBGPState(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1063,7 +1063,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigGetBFDState(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1137,7 +1137,7 @@ func (c *Client) DecixCloudRouterPrefixListsList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1217,7 +1217,7 @@ func (c *Client) DecixCloudRouterPrefixListsCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1290,7 +1290,7 @@ func (c *Client) DecixCloudRouterPrefixListsRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1363,7 +1363,7 @@ func (c *Client) DecixCloudRouterPrefixListsUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1436,7 +1436,7 @@ func (c *Client) DecixCloudRouterPrefixListsDelete(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1508,7 +1508,7 @@ func (c *Client) DecixCloudRouterPoliciesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1588,7 +1588,7 @@ func (c *Client) DecixCloudRouterPoliciesCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1661,7 +1661,7 @@ func (c *Client) DecixCloudRouterPoliciesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1734,7 +1734,7 @@ func (c *Client) DecixCloudRouterPoliciesUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1807,7 +1807,7 @@ func (c *Client) DecixCloudRouterPoliciesDelete(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1882,7 +1882,7 @@ func (c *Client) DecixCloudRouterArpTableList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -1953,7 +1953,7 @@ func (c *Client) DecixCloudRouterVrfRoutesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2028,7 +2028,7 @@ func (c *Client) DecixCloudRouterStaticRoutesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2108,7 +2108,7 @@ func (c *Client) DecixCloudRouterStaticRoutesCreate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2181,7 +2181,7 @@ func (c *Client) DecixCloudRouterStaticRoutesRead(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2254,7 +2254,7 @@ func (c *Client) DecixCloudRouterStaticRoutesUpdate(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2327,7 +2327,7 @@ func (c *Client) DecixCloudRouterStaticRoutesDelete(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2394,7 +2394,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigReceivedRoutesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err
@@ -2451,7 +2451,7 @@ func (c *Client) DecixCloudRouterNetworkServiceConfigAdvertisedRoutesList(
 	if err != nil {
 		return nil, err
 	}
-	defer ret.Body.Close()
+	defer ret.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(ret.Body)
 	if err != nil {
 		return nil, err

--- a/internal/ixapi/resources_cloud_router_test.go
+++ b/internal/ixapi/resources_cloud_router_test.go
@@ -54,7 +54,9 @@ func TestCloudRoutersCreate(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -97,7 +99,9 @@ func TestCloudRoutersRead(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -168,7 +172,9 @@ func TestCloudRoutersList(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -213,7 +219,9 @@ func TestCloudRoutersListWithQuery(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -276,7 +284,9 @@ func TestPrefixListsCreate(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -316,7 +326,9 @@ func TestPrefixListsRead(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -343,7 +355,9 @@ func TestPrefixListsDelete(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(&CloudRouterPrefixList{ID: "pl-1"})
+		if err := json.NewEncoder(w).Encode(&CloudRouterPrefixList{ID: "pl-1"}); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -419,7 +433,9 @@ func TestPoliciesCreate(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -467,7 +483,9 @@ func TestPoliciesRead(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedResp)
+		if err := json.NewEncoder(w).Encode(expectedResp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 

--- a/internal/ixapi/test_client.go
+++ b/internal/ixapi/test_client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -66,7 +66,7 @@ func (t *MockResponseTransport) RoundTrip(req *http.Request) (*http.Response, er
 	if ok {
 		var body []byte
 		if req.Body != nil {
-			body, _ = ioutil.ReadAll(req.Body)
+			body, _ = io.ReadAll(req.Body)
 		}
 		d, err := handlerFunc(body)
 		if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -248,12 +248,13 @@ func configure(
 
 	var provider ixapi.AuthenticationProvider
 	auth := res.Get("auth").(string)
-	if auth == AuthLegacy {
+	switch auth {
+	case AuthLegacy:
 		provider = &ixapi.AuthAPIKeySecret{
 			Key:    key,
 			Secret: secret,
 		}
-	} else if auth == AuthOAuth2 {
+	case AuthOAuth2:
 		tokenURL := res.Get("oauth2_token_url").(string)
 		if err := checkEnvConfig("oauth2_token_url", tokenURL, EnvOAuth2TokenURL); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
@@ -265,9 +266,9 @@ func configure(
 			Scopes:   scopes,
 			TokenURL: tokenURL,
 		}
-	} else {
-		diags = append(diag.FromErr(
-			fmt.Errorf("invalid authentication workflow: %s", auth)))
+	default:
+		diags = append(diags, diag.FromErr(
+			fmt.Errorf("invalid authentication workflow: %s", auth))...)
 	}
 
 	if diags.HasError() {

--- a/internal/resources/account.go
+++ b/internal/resources/account.go
@@ -22,7 +22,7 @@ func NewAccountResource() *schema.Resource {
 		DeleteContext: accountDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.AccountSchema(),
@@ -155,7 +155,9 @@ func accountRead(
 	}
 
 	// Update resource
-	schemas.SetResourceData(acc, res)
+	if err := schemas.SetResourceData(acc, res); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/internal/resources/connection_test.go
+++ b/internal/resources/connection_test.go
@@ -10,10 +10,10 @@ import (
 func TestConnectionRequestFromResourceData(t *testing.T) {
 	resource := NewConnectionResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
-	data.Set("consuming_account", "4242")
-	data.Set("mode", "standalone")
-	data.Set("port_quantity", 2)
+	_ = data.Set("managing_account", "2342")
+	_ = data.Set("consuming_account", "4242")
+	_ = data.Set("mode", "standalone")
+	_ = data.Set("port_quantity", 2)
 
 	req, err := connectionRequestFromResourceData(data)
 	if err != nil {

--- a/internal/resources/contact.go
+++ b/internal/resources/contact.go
@@ -23,7 +23,7 @@ func NewContactResource() *schema.Resource {
 		DeleteContext: contactDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.Combine(
@@ -44,16 +44,7 @@ func NewContactResource() *schema.Resource {
 // helper
 func lookupRoleByName(name string, roles []*ixapi.Role) *ixapi.Role {
 	for _, r := range roles {
-		if strings.ToLower(r.Name) == strings.ToLower(name) {
-			return r
-		}
-	}
-	return nil
-}
-
-func lookupRoleByID(id string, roles []*ixapi.Role) *ixapi.Role {
-	for _, r := range roles {
-		if r.ID == id {
+		if strings.EqualFold(r.Name, name) {
 			return r
 		}
 	}

--- a/internal/resources/contact_test.go
+++ b/internal/resources/contact_test.go
@@ -13,8 +13,8 @@ func TestContactCreate(t *testing.T) {
 	res := resource.Data(nil)
 
 	// Set request
-	res.Set("roles", []string{"noc"})
-	res.Set("email", "email@addr")
+	_ = res.Set("roles", []string{"noc"})
+	_ = res.Set("email", "email@addr")
 
 	contact := testdata.NewContact()
 	roles := []*ixapi.Role{testdata.NewRoleNOC()}

--- a/internal/resources/ip_allocation_network_service_config.go
+++ b/internal/resources/ip_allocation_network_service_config.go
@@ -21,7 +21,7 @@ func NewIPAllocationNetworkServiceConfigResource() *schema.Resource {
 		DeleteContext: crud.Delete(ipAllocationDelete),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -170,6 +170,9 @@ func ipAllocationRead(
 	ips, err := api.IPsList(ctx, &ixapi.IPsListQuery{
 		NetworkServiceConfig: nscID,
 	})
+	if err != nil {
+		return err
+	}
 
 	if len(ips) == 0 {
 		// This is gone

--- a/internal/resources/ip_allocation_network_service_config_test.go
+++ b/internal/resources/ip_allocation_network_service_config_test.go
@@ -10,7 +10,7 @@ import (
 func TestMaybeSetFQDN(t *testing.T) {
 	resource := NewIPAllocationNetworkServiceConfigResource()
 	res := resource.Data(nil)
-	res.Set("fqdn", "gw1.example.ixp")
+	_ = res.Set("fqdn", "gw1.example.ixp")
 
 	ip := &ixapi.IPAddress{
 		ID: "42",

--- a/internal/resources/macs.go
+++ b/internal/resources/macs.go
@@ -22,7 +22,7 @@ func NewMACResource() *schema.Resource {
 		DeleteContext: crud.Delete(macDelete),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.MacAddressSchema(),

--- a/internal/resources/macs_test.go
+++ b/internal/resources/macs_test.go
@@ -5,10 +5,10 @@ import "testing"
 func TestMacRequestFromResourceData(t *testing.T) {
 	resource := NewMACResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "managing:1")
-	res.Set("consuming_account", "consuming:2")
-	res.Set("address", "23:42:12:aa:bb:cc")
-	res.Set("valid_not_before", "2022-10-11T12:23:42Z")
+	_ = res.Set("managing_account", "managing:1")
+	_ = res.Set("consuming_account", "consuming:2")
+	_ = res.Set("address", "23:42:12:aa:bb:cc")
+	_ = res.Set("valid_not_before", "2022-10-11T12:23:42Z")
 
 	req, err := macRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/member_joining_rules.go
+++ b/internal/resources/member_joining_rules.go
@@ -22,7 +22,7 @@ func NewMemberJoiningRuleAllowResource() *schema.Resource {
 		DeleteContext: crud.Delete(mjrAllowDelete),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.AllowMemberJoiningRuleSchema(),
@@ -181,7 +181,7 @@ func NewMemberJoiningRuleDenyResource() *schema.Resource {
 		DeleteContext: crud.Delete(mjrDenyDelete),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.DenyMemberJoiningRuleSchema(),

--- a/internal/resources/member_joining_rules_test.go
+++ b/internal/resources/member_joining_rules_test.go
@@ -11,10 +11,10 @@ import (
 func TestMJRAllowRequestFromResourceData(t *testing.T) {
 	resource := NewMemberJoiningRuleAllowResource()
 	res := resource.Data(nil)
-	res.Set("network_service", "ns:42")
-	res.Set("managing_account", "acc:23")
-	res.Set("consuming_account", "acc:42")
-	res.Set("capacity_max", 42000)
+	_ = res.Set("network_service", "ns:42")
+	_ = res.Set("managing_account", "acc:23")
+	_ = res.Set("consuming_account", "acc:42")
+	_ = res.Set("capacity_max", 42000)
 
 	req, err := mjrAllowRequestFromResourceData(res)
 	if err != nil {
@@ -56,9 +56,9 @@ func TestMJRAllowRead(t *testing.T) {
 func TestMJRDenyRequestFromResourceData(t *testing.T) {
 	resource := NewMemberJoiningRuleDenyResource()
 	res := resource.Data(nil)
-	res.Set("network_service", "ns:42")
-	res.Set("managing_account", "acc:23")
-	res.Set("consuming_account", "acc:42")
+	_ = res.Set("network_service", "ns:42")
+	_ = res.Set("managing_account", "acc:23")
+	_ = res.Set("consuming_account", "acc:42")
 
 	req, err := mjrDenyRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/network_feature_config_route_server.go
+++ b/internal/resources/network_feature_config_route_server.go
@@ -22,7 +22,7 @@ func NewNetworkFeatureConfigRouteServerResource() *schema.Resource {
 		DeleteContext: crud.Delete(nfcRouteServerDelete),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: schemas.RouteServerNetworkFeatureConfigSchema(),

--- a/internal/resources/network_service_cloud_vc.go
+++ b/internal/resources/network_service_cloud_vc.go
@@ -22,7 +22,7 @@ func NewNetworkServiceCloudVCResource() *schema.Resource {
 		Schema: schemas.CloudNetworkServiceSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_cloud_vc_test.go
+++ b/internal/resources/network_service_cloud_vc_test.go
@@ -11,10 +11,10 @@ import (
 func TestCloudVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceCloudVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "managing:1")
-	res.Set("consuming_account", "consuming:2")
-	res.Set("cloud_key", "cloudkey")
-	res.Set("capacity", 42000)
+	_ = res.Set("managing_account", "managing:1")
+	_ = res.Set("consuming_account", "consuming:2")
+	_ = res.Set("cloud_key", "cloudkey")
+	_ = res.Set("capacity", 42000)
 
 	req, err := nsCloudVCRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/network_service_config.go
+++ b/internal/resources/network_service_config.go
@@ -38,7 +38,7 @@ func VlanConfigFromResourceData(r *schema.ResourceData) (ixapi.VLANConfig, error
 		outerVlan := c.GetIntOpt("outer_vlan")
 		innerVlan := c.GetIntOpt("inner_vlan")
 		if innerVlan == nil {
-			return nil, fmt.Errorf("The `inner_vlan` property is required for qinq vlan configs")
+			return nil, fmt.Errorf("the `inner_vlan` property is required for qinq vlan configs")
 		}
 		cfg := &ixapi.VLANConfigQinQ{
 			VLANType:           "qinq",

--- a/internal/resources/network_service_config_cloud_vc.go
+++ b/internal/resources/network_service_config_cloud_vc.go
@@ -23,7 +23,7 @@ func NewNetworkServiceConfigCloudVCResource() *schema.Resource {
 		Schema: schemas.CloudNetworkServiceConfigSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_config_exchange_lan.go
+++ b/internal/resources/network_service_config_exchange_lan.go
@@ -24,7 +24,7 @@ func NewNetworkServiceConfigExchangeLanResource() *schema.Resource {
 		Schema: schemas.ExchangeLanNetworkServiceConfigSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_config_mp2mp_vc.go
+++ b/internal/resources/network_service_config_mp2mp_vc.go
@@ -23,7 +23,7 @@ func NewNetworkServiceConfigMP2MPVCResource() *schema.Resource {
 		Schema: schemas.MP2MPNetworkServiceConfigSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_config_p2mp_vc.go
+++ b/internal/resources/network_service_config_p2mp_vc.go
@@ -23,7 +23,7 @@ func NewNetworkServiceConfigP2MPVCResource() *schema.Resource {
 		Schema: schemas.P2MPNetworkServiceConfigSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_config_p2p_vc.go
+++ b/internal/resources/network_service_config_p2p_vc.go
@@ -23,7 +23,7 @@ func NewNetworkServiceConfigP2PVCResource() *schema.Resource {
 		Schema: schemas.P2PNetworkServiceConfigSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_config_test.go
+++ b/internal/resources/network_service_config_test.go
@@ -48,7 +48,7 @@ func TestVlanConfigFromResourceDataPort(t *testing.T) {
 func TestNscExchangeLanRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceConfigExchangeLanResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
+	_ = data.Set("managing_account", "2342")
 
 	req, err := nscExchangeLanRequestFromResourceData(data)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestNscExchangeLanRequestFromResourceData(t *testing.T) {
 func TestNscP2PVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceConfigP2PVCResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
+	_ = data.Set("managing_account", "2342")
 
 	req, err := nscP2PVCRequestFromResourceData(data)
 	if err != nil {
@@ -88,7 +88,7 @@ func TestNscP2PVCRequestFromResourceData(t *testing.T) {
 func TestNscCloudVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceConfigCloudVCResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
+	_ = data.Set("managing_account", "2342")
 
 	req, err := nscCloudVCRequestFromResourceData(data)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestNscCloudVCRequestFromResourceData(t *testing.T) {
 func TestNscMP2MPVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceConfigMP2MPVCResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
+	_ = data.Set("managing_account", "2342")
 
 	req, err := nscMP2MPVCRequestFromResourceData(data)
 	if err != nil {
@@ -128,7 +128,7 @@ func TestNscMP2MPVCRequestFromResourceData(t *testing.T) {
 func TestNscP2MPVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceConfigP2MPVCResource()
 	data := resource.Data(nil)
-	data.Set("managing_account", "2342")
+	_ = data.Set("managing_account", "2342")
 
 	req, err := nscP2MPVCRequestFromResourceData(data)
 	if err != nil {

--- a/internal/resources/network_service_mp2mp_vc.go
+++ b/internal/resources/network_service_mp2mp_vc.go
@@ -22,7 +22,7 @@ func NewNetworkServiceMP2MPVCResource() *schema.Resource {
 		Schema: schemas.MP2MPNetworkServiceSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_mp2mp_vc_test.go
+++ b/internal/resources/network_service_mp2mp_vc_test.go
@@ -11,10 +11,10 @@ import (
 func TestMP2MPVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceMP2MPVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "managing:1")
-	res.Set("consuming_account", "consuming:2")
-	res.Set("display_name", "vc 1")
-	res.Set("public", true)
+	_ = res.Set("managing_account", "managing:1")
+	_ = res.Set("consuming_account", "consuming:2")
+	_ = res.Set("display_name", "vc 1")
+	_ = res.Set("public", true)
 
 	req, err := nsMP2MPVCRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/network_service_p2mp_vc.go
+++ b/internal/resources/network_service_p2mp_vc.go
@@ -22,7 +22,7 @@ func NewNetworkServiceP2MPVCResource() *schema.Resource {
 		Schema: schemas.P2MPNetworkServiceSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_p2mp_vc_test.go
+++ b/internal/resources/network_service_p2mp_vc_test.go
@@ -11,10 +11,10 @@ import (
 func TestP2MPVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceP2MPVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "managing:1")
-	res.Set("consuming_account", "consuming:2")
-	res.Set("display_name", "vc 1")
-	res.Set("public", true)
+	_ = res.Set("managing_account", "managing:1")
+	_ = res.Set("consuming_account", "consuming:2")
+	_ = res.Set("display_name", "vc 1")
+	_ = res.Set("public", true)
 
 	req, err := nsP2MPVCRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/network_service_p2p_vc.go
+++ b/internal/resources/network_service_p2p_vc.go
@@ -22,7 +22,7 @@ func NewNetworkServiceP2PVCResource() *schema.Resource {
 		Schema: schemas.P2PNetworkServiceSchema(),
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/internal/resources/network_service_p2p_vc_test.go
+++ b/internal/resources/network_service_p2p_vc_test.go
@@ -11,10 +11,10 @@ import (
 func TestP2PVCRequestFromResourceData(t *testing.T) {
 	resource := NewNetworkServiceP2PVCResource()
 	res := resource.Data(nil)
-	res.Set("managing_account", "managing:1")
-	res.Set("consuming_account", "consuming:2")
-	res.Set("joining_member_account", "joining:3")
-	res.Set("display_name", "p2p vc 1")
+	_ = res.Set("managing_account", "managing:1")
+	_ = res.Set("consuming_account", "consuming:2")
+	_ = res.Set("joining_member_account", "joining:3")
+	_ = res.Set("display_name", "p2p vc 1")
 
 	req, err := nsP2PVCRequestFromResourceData(res)
 	if err != nil {

--- a/internal/resources/network_service_test.go
+++ b/internal/resources/network_service_test.go
@@ -13,7 +13,7 @@ func TestVLanConfigFromResourceDataPort(t *testing.T) {
 	vlanConfig := map[string]any{
 		"vlan_type": "port",
 	}
-	res.Set("vlan_config", []any{vlanConfig})
+	_ = res.Set("vlan_config", []any{vlanConfig})
 
 	config, err := VlanConfigFromResourceData(res)
 	if err != nil {
@@ -34,7 +34,7 @@ func TestVLanConfigFromResourceDataDot1Q(t *testing.T) {
 		"vlan_type": "dot1q",
 		"vlan":      42,
 	}
-	res.Set("vlan_config", []any{vlanConfig})
+	_ = res.Set("vlan_config", []any{vlanConfig})
 
 	config, err := VlanConfigFromResourceData(res)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestVLanConfigFromResourceDataQinQ(t *testing.T) {
 		"outer_vlan":           23,
 		"outer_vlan_ethertype": "0x2342",
 	}
-	res.Set("vlan_config", []any{vlanConfig})
+	_ = res.Set("vlan_config", []any{vlanConfig})
 
 	config, err := VlanConfigFromResourceData(res)
 	if err != nil {

--- a/internal/resources/port_reservation.go
+++ b/internal/resources/port_reservation.go
@@ -177,11 +177,11 @@ func portReservationUpdate(
 ) error {
 	if res.HasChange("port_num") {
 		return fmt.Errorf(
-			"The `port_num` property can not be updated, you need to create a new resource")
+			"the `port_num` property can not be updated, you need to create a new resource")
 	}
 	if res.HasChange("network_connection") {
 		return fmt.Errorf(
-			"The `network_connection` can not be changed, you need to create a new resource")
+			"the `network_connection` can not be changed, you need to create a new resource")
 	}
 
 	// Make patch from resource data

--- a/internal/schemas/datasources.go
+++ b/internal/schemas/datasources.go
@@ -2,13 +2,6 @@ package schemas
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-func boolFromOption(b []bool) bool {
-	if len(b) > 0 {
-		return b[0]
-	}
-	return false
-}
-
 // DataSourceQuery creates a string data source schema
 // used for querying.
 // We assume string as the type, as this is the case for

--- a/internal/schemas/reflect.go
+++ b/internal/schemas/reflect.go
@@ -77,23 +77,33 @@ func SetResourceData(model any, res ResourceSetter) error {
 		}
 
 		if fType.String() == "*ixapi.Date" {
-			res.Set(propName, val.Interface().(*ixapi.Date).String())
+			if err := res.Set(propName, val.Interface().(*ixapi.Date).String()); err != nil {
+				return err
+			}
 			continue
 		}
 		if fType.String() == "*ixapi.APITimestamp" {
-			res.Set(propName, val.Interface().(*ixapi.APITimestamp).Time.Format(time.RFC3339))
+			if err := res.Set(propName, val.Interface().(*ixapi.APITimestamp).Format(time.RFC3339)); err != nil {
+				return err
+			}
 			continue
 		}
 		if fType.String() == "ixapi.APITimestamp" {
-			res.Set(propName, val.Interface().(ixapi.APITimestamp).Time.Format(time.RFC3339))
+			if err := res.Set(propName, val.Interface().(ixapi.APITimestamp).Format(time.RFC3339)); err != nil {
+				return err
+			}
 			continue
 		}
 		if fType.String() == "*time.Time" {
-			res.Set(propName, val.Interface().(*time.Time).Format(time.RFC3339))
+			if err := res.Set(propName, val.Interface().(*time.Time).Format(time.RFC3339)); err != nil {
+				return err
+			}
 			continue
 		}
 		if valT.PkgPath() == "time" && valT.Name() == "Time" {
-			res.Set(propName, val.Interface().(time.Time).Format(time.RFC3339))
+			if err := res.Set(propName, val.Interface().(time.Time).Format(time.RFC3339)); err != nil {
+				return err
+			}
 			continue
 		}
 

--- a/internal/schemas/reflect_test.go
+++ b/internal/schemas/reflect_test.go
@@ -42,7 +42,9 @@ const CreateMacResponse = `{"managing_account":"17","consuming_account":"26","ex
 
 func TestSetResourceMac(t *testing.T) {
 	mac := &ixapi.MacAddress{}
-	json.Unmarshal([]byte(CreateMacResponse), mac)
+	if err := json.Unmarshal([]byte(CreateMacResponse), mac); err != nil {
+		t.Fatal(err)
+	}
 
 	res := NewFlatResource()
 	err := SetResourceData(mac, res)

--- a/internal/schemas/resource_data_test.go
+++ b/internal/schemas/resource_data_test.go
@@ -18,7 +18,7 @@ func TestGetTimeOpt_RFC3339(t *testing.T) {
 	}
 
 	rd := s.Data(nil)
-	rd.Set("timestamp", "2024-08-01T14:30:00Z")
+	_ = rd.Set("timestamp", "2024-08-01T14:30:00Z")
 
 	res := ResourceData{ResourceData: rd}
 	ts, err := res.GetTimeOpt("timestamp")
@@ -46,7 +46,7 @@ func TestGetTimeOpt_DateOnly(t *testing.T) {
 	}
 
 	rd := s.Data(nil)
-	rd.Set("date", "2024-08-01")
+	_ = rd.Set("date", "2024-08-01")
 
 	res := ResourceData{ResourceData: rd}
 	ts, err := res.GetTimeOpt("date")
@@ -96,7 +96,7 @@ func TestGetTimeOpt_InvalidFormat(t *testing.T) {
 	}
 
 	rd := s.Data(nil)
-	rd.Set("timestamp", "not-a-date")
+	_ = rd.Set("timestamp", "not-a-date")
 
 	res := ResourceData{ResourceData: rd}
 	_, err := res.GetTimeOpt("timestamp")

--- a/main.go
+++ b/main.go
@@ -10,10 +10,7 @@ import (
 
 // Run the docs generation tool:
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-var (
-	version string = "dev"
-	commit  string = "head"
-)
+var version string = "dev"
 
 // Flags
 var (


### PR DESCRIPTION
Golangci-lint found a substantial amount of missing errchecks and unnecessarily complex expressions.
The fixes are very repetitive and were mostly:

 - adding missing if err:= .. or
 - ignoring the return value in tests

other than that two deprecation warnings: schema.ImportStatePassthroughContext instead of schema.ImportStatePassthrough (State -> StateContext)
and io/ioutil



