### PR TITLE
Add user agent to http client

### DIFF
--- a/internal/ixapi/client.go
+++ b/internal/ixapi/client.go
@@ -78,11 +78,15 @@ type Client struct {
 }
 
 // NewClient creates a new client instance
-func NewClient(server string) *Client {
-	return &Client{
+func NewClient(server, version string) *Client {
+	c := &Client{
 		APIURL: server,
 		header: http.Header{},
 	}
+	if version != "" {
+		c.header.Set("User-Agent", "terraform-provider-ixapi/"+version)
+	}
+	return c
 }
 
 // hostBase extracts only the scheme and host from a URL, stripping any path component.
@@ -108,11 +112,6 @@ func (c *Client) resourceURL(res string, params ...string) string {
 // This can be used to implement custom authentication.
 func (c *Client) SetBearer(token string) {
 	c.header.Set("Authorization", "Bearer "+token)
-}
-
-// SetUserAgent sets the User-Agent header sent with every request.
-func (c *Client) SetUserAgent(ua string) {
-	c.header.Set("User-Agent", ua)
 }
 
 // Authenticate using a authentication provider

--- a/internal/ixapi/client.go
+++ b/internal/ixapi/client.go
@@ -68,6 +68,12 @@ func (flow *OAuth2ClientCredentials) authenticate(
 	return nil
 }
 
+// ClientConfig holds the configuration for a new Client.
+type ClientConfig struct {
+	Host      string
+	UserAgent string
+}
+
 // Client is an IX-API http client
 type Client struct {
 	http.Client
@@ -78,13 +84,13 @@ type Client struct {
 }
 
 // NewClient creates a new client instance
-func NewClient(server, version string) *Client {
+func NewClient(cfg ClientConfig) *Client {
 	c := &Client{
-		APIURL: server,
+		APIURL: cfg.Host,
 		header: http.Header{},
 	}
-	if version != "" {
-		c.header.Set("User-Agent", "terraform-provider-ixapi/"+version)
+	if cfg.UserAgent != "" {
+		c.header.Set("User-Agent", cfg.UserAgent)
 	}
 	return c
 }

--- a/internal/ixapi/client.go
+++ b/internal/ixapi/client.go
@@ -110,6 +110,11 @@ func (c *Client) SetBearer(token string) {
 	c.header.Set("Authorization", "Bearer "+token)
 }
 
+// SetUserAgent sets the User-Agent header sent with every request.
+func (c *Client) SetUserAgent(ua string) {
+	c.header.Set("User-Agent", ua)
+}
+
 // Authenticate using a authentication provider
 func (c *Client) Authenticate(
 	ctx context.Context,

--- a/internal/ixapi/client.go
+++ b/internal/ixapi/client.go
@@ -68,10 +68,11 @@ func (flow *OAuth2ClientCredentials) authenticate(
 	return nil
 }
 
-// ClientConfig holds the configuration for a new Client.
-type ClientConfig struct {
-	Host      string
-	UserAgent string
+var version string
+
+// SetVersion sets the provider version used in the User-Agent header.
+func SetVersion(v string) {
+	version = v
 }
 
 // Client is an IX-API http client
@@ -84,13 +85,13 @@ type Client struct {
 }
 
 // NewClient creates a new client instance
-func NewClient(cfg ClientConfig) *Client {
+func NewClient(server string) *Client {
 	c := &Client{
-		APIURL: cfg.Host,
+		APIURL: server,
 		header: http.Header{},
 	}
-	if cfg.UserAgent != "" {
-		c.header.Set("User-Agent", cfg.UserAgent)
+	if version != "" {
+		c.header.Set("User-Agent", "terraform-provider-ixapi/"+version)
 	}
 	return c
 }

--- a/internal/ixapi/client_test.go
+++ b/internal/ixapi/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestSetUserAgent(t *testing.T) {
+func TestNewClientSetsUserAgent(t *testing.T) {
 	var capturedUA string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -20,8 +20,7 @@ func TestSetUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
-	client.SetUserAgent("terraform-provider-ixapi/1.2.3")
+	client := NewClient(server.URL, "1.2.3")
 
 	_, err := client.DecixCloudRoutersList(context.Background())
 	if err != nil {

--- a/internal/ixapi/client_test.go
+++ b/internal/ixapi/client_test.go
@@ -20,10 +20,8 @@ func TestNewClientSetsUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{
-		Host:      server.URL,
-		UserAgent: "terraform-provider-ixapi/1.2.3",
-	})
+	SetVersion("1.2.3")
+	client := NewClient(server.URL)
 
 	_, err := client.DecixCloudRoutersList(context.Background())
 	if err != nil {

--- a/internal/ixapi/client_test.go
+++ b/internal/ixapi/client_test.go
@@ -20,7 +20,10 @@ func TestNewClientSetsUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "1.2.3")
+	client := NewClient(ClientConfig{
+		Host:      server.URL,
+		UserAgent: "terraform-provider-ixapi/1.2.3",
+	})
 
 	_, err := client.DecixCloudRoutersList(context.Background())
 	if err != nil {

--- a/internal/ixapi/client_test.go
+++ b/internal/ixapi/client_test.go
@@ -1,0 +1,35 @@
+package ixapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSetUserAgent(t *testing.T) {
+	var capturedUA string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode([]CloudRouter{}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	client.SetUserAgent("terraform-provider-ixapi/1.2.3")
+
+	_, err := client.DecixCloudRoutersList(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "terraform-provider-ixapi/1.2.3"
+	if capturedUA != expected {
+		t.Errorf("expected User-Agent %q, got %q", expected, capturedUA)
+	}
+}

--- a/internal/ixapi/resources_cloud_router_test.go
+++ b/internal/ixapi/resources_cloud_router_test.go
@@ -60,7 +60,7 @@ func TestCloudRoutersCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersCreate(ctx, expectedReq)
@@ -105,7 +105,7 @@ func TestCloudRoutersRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersRead(ctx, "vrf-1")
@@ -134,7 +134,7 @@ func TestCloudRoutersDestroy(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	err := client.DecixCloudRoutersDestroy(ctx, "vrf-1")
@@ -178,7 +178,7 @@ func TestCloudRoutersList(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersList(ctx)
@@ -225,7 +225,7 @@ func TestCloudRoutersListWithQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	qry := &CloudRoutersListQuery{
@@ -290,7 +290,7 @@ func TestPrefixListsCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsCreate(ctx, expectedReq)
@@ -332,7 +332,7 @@ func TestPrefixListsRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsRead(ctx, "pl-1")
@@ -361,7 +361,7 @@ func TestPrefixListsDelete(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	_, err := client.DecixCloudRouterPrefixListsDelete(ctx, "pl-1")
@@ -439,7 +439,7 @@ func TestPoliciesCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesCreate(ctx, expectedReq)
@@ -489,7 +489,7 @@ func TestPoliciesRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, "")
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesRead(ctx, "pol-1")

--- a/internal/ixapi/resources_cloud_router_test.go
+++ b/internal/ixapi/resources_cloud_router_test.go
@@ -60,7 +60,7 @@ func TestCloudRoutersCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersCreate(ctx, expectedReq)
@@ -105,7 +105,7 @@ func TestCloudRoutersRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersRead(ctx, "vrf-1")
@@ -134,7 +134,7 @@ func TestCloudRoutersDestroy(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	err := client.DecixCloudRoutersDestroy(ctx, "vrf-1")
@@ -178,7 +178,7 @@ func TestCloudRoutersList(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersList(ctx)
@@ -225,7 +225,7 @@ func TestCloudRoutersListWithQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	qry := &CloudRoutersListQuery{
@@ -290,7 +290,7 @@ func TestPrefixListsCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsCreate(ctx, expectedReq)
@@ -332,7 +332,7 @@ func TestPrefixListsRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsRead(ctx, "pl-1")
@@ -361,7 +361,7 @@ func TestPrefixListsDelete(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	_, err := client.DecixCloudRouterPrefixListsDelete(ctx, "pl-1")
@@ -439,7 +439,7 @@ func TestPoliciesCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesCreate(ctx, expectedReq)
@@ -489,7 +489,7 @@ func TestPoliciesRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "")
+	client := NewClient(ClientConfig{Host: server.URL})
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesRead(ctx, "pol-1")

--- a/internal/ixapi/resources_cloud_router_test.go
+++ b/internal/ixapi/resources_cloud_router_test.go
@@ -60,7 +60,7 @@ func TestCloudRoutersCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersCreate(ctx, expectedReq)
@@ -105,7 +105,7 @@ func TestCloudRoutersRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersRead(ctx, "vrf-1")
@@ -134,7 +134,7 @@ func TestCloudRoutersDestroy(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	err := client.DecixCloudRoutersDestroy(ctx, "vrf-1")
@@ -178,7 +178,7 @@ func TestCloudRoutersList(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRoutersList(ctx)
@@ -225,7 +225,7 @@ func TestCloudRoutersListWithQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	qry := &CloudRoutersListQuery{
@@ -290,7 +290,7 @@ func TestPrefixListsCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsCreate(ctx, expectedReq)
@@ -332,7 +332,7 @@ func TestPrefixListsRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPrefixListsRead(ctx, "pl-1")
@@ -361,7 +361,7 @@ func TestPrefixListsDelete(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	_, err := client.DecixCloudRouterPrefixListsDelete(ctx, "pl-1")
@@ -439,7 +439,7 @@ func TestPoliciesCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesCreate(ctx, expectedReq)
@@ -489,7 +489,7 @@ func TestPoliciesRead(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(ClientConfig{Host: server.URL})
+	client := NewClient(server.URL)
 	ctx := context.Background()
 
 	result, err := client.DecixCloudRouterPoliciesRead(ctx, "pol-1")

--- a/internal/ixapi/test_client.go
+++ b/internal/ixapi/test_client.go
@@ -32,7 +32,7 @@ type TestResponseFunc func(body []byte) (any, error)
 // with a custom response for a request endpoint.
 // The response will be encoded as json.
 func NewTestClient(responses map[string]any) *Client {
-	c := NewClient("") // plain http client
+	c := NewClient("", "")
 	c.Transport = NewMockResponseTransport(responses)
 	return c
 }

--- a/internal/ixapi/test_client.go
+++ b/internal/ixapi/test_client.go
@@ -32,7 +32,7 @@ type TestResponseFunc func(body []byte) (any, error)
 // with a custom response for a request endpoint.
 // The response will be encoded as json.
 func NewTestClient(responses map[string]any) *Client {
-	c := NewClient(ClientConfig{})
+	c := NewClient("")
 	c.Transport = NewMockResponseTransport(responses)
 	return c
 }

--- a/internal/ixapi/test_client.go
+++ b/internal/ixapi/test_client.go
@@ -32,7 +32,7 @@ type TestResponseFunc func(body []byte) (any, error)
 // with a custom response for a request endpoint.
 // The response will be encoded as json.
 func NewTestClient(responses map[string]any) *Client {
-	c := NewClient("", "")
+	c := NewClient(ClientConfig{})
 	c.Transport = NewMockResponseTransport(responses)
 	return c
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -279,7 +279,10 @@ func configure(
 	}
 
 	// Create client and authenticate with legacy strategy
-	client := ixapi.NewClient(host, version)
+	client := ixapi.NewClient(ixapi.ClientConfig{
+		Host:      host,
+		UserAgent: "terraform-provider-ixapi/" + version,
+	})
 	if err := client.Authenticate(ctx, provider); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -279,8 +279,7 @@ func configure(
 	}
 
 	// Create client and authenticate with legacy strategy
-	client := ixapi.NewClient(host)
-	client.SetUserAgent("terraform-provider-ixapi/" + version)
+	client := ixapi.NewClient(host, version)
 	if err := client.Authenticate(ctx, provider); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,7 +60,7 @@ func init() {
 }
 
 // New creates a new provider function
-func New(version string) func() *schema.Provider {
+func New() func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
@@ -218,7 +218,7 @@ func New(version string) func() *schema.Provider {
 				"ixapi_ip_allocation_network_service_config": resources.NewIPAllocationNetworkServiceConfigResource(),
 			},
 			ConfigureContextFunc: func(ctx context.Context, res *schema.ResourceData) (any, diag.Diagnostics) {
-				return configure(ctx, res, version)
+				return configure(ctx, res)
 			},
 		}
 		return p
@@ -229,7 +229,6 @@ func New(version string) func() *schema.Provider {
 func configure(
 	ctx context.Context,
 	res *schema.ResourceData,
-	version string,
 ) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -279,10 +278,7 @@ func configure(
 	}
 
 	// Create client and authenticate with legacy strategy
-	client := ixapi.NewClient(ixapi.ClientConfig{
-		Host:      host,
-		UserAgent: "terraform-provider-ixapi/" + version,
-	})
+	client := ixapi.NewClient(host)
 	if err := client.Authenticate(ctx, provider); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -217,7 +217,9 @@ func New(version string) func() *schema.Provider {
 
 				"ixapi_ip_allocation_network_service_config": resources.NewIPAllocationNetworkServiceConfigResource(),
 			},
-			ConfigureContextFunc: configure,
+			ConfigureContextFunc: func(ctx context.Context, res *schema.ResourceData) (any, diag.Diagnostics) {
+				return configure(ctx, res, version)
+			},
 		}
 		return p
 	}
@@ -227,6 +229,7 @@ func New(version string) func() *schema.Provider {
 func configure(
 	ctx context.Context,
 	res *schema.ResourceData,
+	version string,
 ) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -277,6 +280,7 @@ func configure(
 
 	// Create client and authenticate with legacy strategy
 	client := ixapi.NewClient(host)
+	client.SetUserAgent("terraform-provider-ixapi/" + version)
 	if err := client.Authenticate(ctx, provider); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestProvider(t *testing.T) {
-	p := New("dev")
+	p := New()
 	if err := p().InternalValidate(); err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 
+	"github.com/ix-api-net/terraform-provider-ixapi/internal/ixapi"
 	"github.com/ix-api-net/terraform-provider-ixapi/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -28,11 +29,12 @@ func init() {
 
 func main() {
 	flag.Parse()
+	ixapi.SetVersion(version)
 
 	opts := &plugin.ServeOpts{
 		Debug:        debug,
 		ProviderAddr: "registry.terraform.io/ix-api-net/terraform-provider-ixapi",
-		ProviderFunc: provider.New(version),
+		ProviderFunc: provider.New(),
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
Sets the User-Agent header to `"terraform-provider-ixapi/<version>"` so that traffic can be discriminated server-side.